### PR TITLE
Add https and chinese characters support

### DIFF
--- a/iTunes#Algeria.src
+++ b/iTunes#Algeria.src
@@ -9,13 +9,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=DZ&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=DZ&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=DZ&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=DZ&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #
@@ -26,7 +26,7 @@ findline "wrapperType\""
 do
 	joinuntil "}"
               replace "\\\"" "&quot;"
-	      replace "?uo=4" ""	  
+	      replace "?uo=4" ""
 
 	# PREVIEW
 	sayregexp "(?<=\"collectionViewUrl\":\").+?(?=\")" ", " "}"
@@ -158,11 +158,11 @@ do
 	outputto "GENRE"
 	sayregexp "(?<=\"primaryGenreName\":\").+?(?=\")" ", " "}"
 	say "|"
-	
+
 	outputto "_LENGTH"
 	sayregexp "(?<=\"trackTimeMillis\":)\d+?(?=\D)" ", " "}"
 	say "|"
-	
+
 	OutputTo "DISCNUMBER"
 	FindLine "\"discNumber\":"
 	FindInLine "\"discNumber\":"

--- a/iTunes#Angola.src
+++ b/iTunes#Angola.src
@@ -9,13 +9,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=AO&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=AO&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=AO&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=AO&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Anguilla.src
+++ b/iTunes#Anguilla.src
@@ -9,13 +9,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=AI&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=AI&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=AI&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=AI&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Antigua and Barbuda.src
+++ b/iTunes#Antigua and Barbuda.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=AG&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=AG&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=AG&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=AG&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Argentina.src
+++ b/iTunes#Argentina.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=AR&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=AR&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=AR&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=AR&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Armenia.src
+++ b/iTunes#Armenia.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=AM&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=AM&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=AM&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=AM&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Australia.src
+++ b/iTunes#Australia.src
@@ -9,13 +9,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=AU&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=AU&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=AU&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=AU&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Austria.src
+++ b/iTunes#Austria.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=AT&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=AT&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=AT&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=AT&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Azerbaijan.src
+++ b/iTunes#Azerbaijan.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=AZ&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=AZ&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=AZ&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=AZ&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Bahrain.src
+++ b/iTunes#Bahrain.src
@@ -9,13 +9,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=BH&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=BH&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=BH&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=BH&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Bangladesh.src
+++ b/iTunes#Bangladesh.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=BD&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=BD&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=BD&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=BD&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Belgium.src
+++ b/iTunes#Belgium.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=BE&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=BE&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=BE&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=BE&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Bermuda.src
+++ b/iTunes#Bermuda.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=BM&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=BM&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=BM&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=BM&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Bolivia.src
+++ b/iTunes#Bolivia.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=BO&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=BO&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=BO&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=BO&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Botswana.src
+++ b/iTunes#Botswana.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=BW&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=BW&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=BW&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=BW&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Brazil.src
+++ b/iTunes#Brazil.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=BR&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=BR&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=BR&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=BR&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#British Virgin Islands.src
+++ b/iTunes#British Virgin Islands.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=VG&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=VG&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=VG&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=VG&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Canada.src
+++ b/iTunes#Canada.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=CA&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=CA&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=CA&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=CA&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Chile.src
+++ b/iTunes#Chile.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=CL&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=CL&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=CL&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=CL&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#China.src
+++ b/iTunes#China.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=CN&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=CN&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=CN&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=CN&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#China.src
+++ b/iTunes#China.src
@@ -11,8 +11,8 @@
 ########################################################
 [Name]=iTunes
 [BasedOn]=https://itunes.apple.com
-[IndexUrl]=https://itunes.apple.com/search?country=CN&entity=album&term=%s
-[AlbumUrl]=https://itunes.apple.com/lookup?country=CN&entity=song&limit=200&id=
+[IndexUrl]=https://itunes.apple.com/search?country=CN&entity=album&l=zh&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=CN&entity=song&l=zh&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
@@ -27,7 +27,7 @@ findline "wrapperType\""
 do
 	joinuntil "}"
               replace "\\\"" "&quot;"
-	      replace "?uo=4" ""	  
+	      replace "?uo=4" ""
 
 	# PREVIEW
 	sayregexp "(?<=\"collectionViewUrl\":\").+?(?=\")" ", " "}"
@@ -159,11 +159,11 @@ do
 	outputto "GENRE"
 	sayregexp "(?<=\"primaryGenreName\":\").+?(?=\")" ", " "}"
 	say "|"
-	
+
 	outputto "_LENGTH"
 	sayregexp "(?<=\"trackTimeMillis\":)\d+?(?=\D)" ", " "}"
 	say "|"
-	
+
 	OutputTo "DISCNUMBER"
 	FindLine "\"discNumber\":"
 	FindInLine "\"discNumber\":"

--- a/iTunes#Colombia.src
+++ b/iTunes#Colombia.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=CO&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=CO&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=CO&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=CO&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Costa Rica.src
+++ b/iTunes#Costa Rica.src
@@ -9,13 +9,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=CR&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=CR&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=CR&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=CR&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Czech Republic.src
+++ b/iTunes#Czech Republic.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=CZ&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=CZ&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=CZ&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=CZ&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Denmark.src
+++ b/iTunes#Denmark.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=DK&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=DK&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=DK&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=DK&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Egypt.src
+++ b/iTunes#Egypt.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=EG&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=EG&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=EG&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=EG&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#El Salvador.src
+++ b/iTunes#El Salvador.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=SV&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=SV&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=SV&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=SV&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Emirate.src
+++ b/iTunes#Emirate.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=AE&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=AE&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=AE&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=AE&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Estonia.src
+++ b/iTunes#Estonia.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=EE&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=EE&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=EE&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=EE&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Finland.src
+++ b/iTunes#Finland.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=FI&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=FI&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=FI&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=FI&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#France.src
+++ b/iTunes#France.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=FA&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=FA&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=FA&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=FA&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Germany.src
+++ b/iTunes#Germany.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=DE&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=DE&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=DE&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=DE&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Ghana.src
+++ b/iTunes#Ghana.src
@@ -9,13 +9,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=GH&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=GH&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=GH&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=GH&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Greece.src
+++ b/iTunes#Greece.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=GR&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=GR&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=GR&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=GR&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Grenada.src
+++ b/iTunes#Grenada.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=GD&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=GD&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=GD&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=GD&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Guatemala.src
+++ b/iTunes#Guatemala.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=GT&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=GT&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=GT&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=GT&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Guyana.src
+++ b/iTunes#Guyana.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=GY&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=GY&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=GY&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=GY&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Hong Kong.src
+++ b/iTunes#Hong Kong.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=HK&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=HK&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=HK&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=HK&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Hong Kong.src
+++ b/iTunes#Hong Kong.src
@@ -11,8 +11,8 @@
 ########################################################
 [Name]=iTunes
 [BasedOn]=https://itunes.apple.com
-[IndexUrl]=https://itunes.apple.com/search?country=HK&entity=album&term=%s
-[AlbumUrl]=https://itunes.apple.com/lookup?country=HK&entity=song&limit=200&id=
+[IndexUrl]=https://itunes.apple.com/search?country=HK&entity=album&l=zh&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=HK&entity=song&l=zh&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
@@ -27,7 +27,7 @@ findline "wrapperType\""
 do
 	joinuntil "}"
               replace "\\\"" "&quot;"
-	      replace "?uo=4" ""	  
+	      replace "?uo=4" ""
 
 	# PREVIEW
 	sayregexp "(?<=\"collectionViewUrl\":\").+?(?=\")" ", " "}"
@@ -159,11 +159,11 @@ do
 	outputto "GENRE"
 	sayregexp "(?<=\"primaryGenreName\":\").+?(?=\")" ", " "}"
 	say "|"
-	
+
 	outputto "_LENGTH"
 	sayregexp "(?<=\"trackTimeMillis\":)\d+?(?=\D)" ", " "}"
 	say "|"
-	
+
 	OutputTo "DISCNUMBER"
 	FindLine "\"discNumber\":"
 	FindInLine "\"discNumber\":"

--- a/iTunes#Iceland.src
+++ b/iTunes#Iceland.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=IS&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=IS&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=IS&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=IS&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#India.src
+++ b/iTunes#India.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=IN&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=IN&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=IN&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=IN&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Italia.src
+++ b/iTunes#Italia.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=IT&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=IT&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=IT&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=IT&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Jamaica.src
+++ b/iTunes#Jamaica.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=JM&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=JM&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=JM&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=JM&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Japan.src
+++ b/iTunes#Japan.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=JP&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=JP&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=JP&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=JP&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Japan.src
+++ b/iTunes#Japan.src
@@ -11,8 +11,8 @@
 ########################################################
 [Name]=iTunes
 [BasedOn]=https://itunes.apple.com
-[IndexUrl]=https://itunes.apple.com/search?country=JP&entity=album&term=%s
-[AlbumUrl]=https://itunes.apple.com/lookup?country=JP&entity=song&limit=200&id=
+[IndexUrl]=https://itunes.apple.com/search?country=JP&entity=album&l=jp&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=JP&entity=song&l=jp&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
@@ -27,7 +27,7 @@ findline "wrapperType\""
 do
 	joinuntil "}"
               replace "\\\"" "&quot;"
-	      replace "?uo=4" ""	  
+	      replace "?uo=4" ""
 
 	# PREVIEW
 	sayregexp "(?<=\"collectionViewUrl\":\").+?(?=\")" ", " "}"
@@ -159,11 +159,11 @@ do
 	outputto "GENRE"
 	sayregexp "(?<=\"primaryGenreName\":\").+?(?=\")" ", " "}"
 	say "|"
-	
+
 	outputto "_LENGTH"
 	sayregexp "(?<=\"trackTimeMillis\":)\d+?(?=\D)" ", " "}"
 	say "|"
-	
+
 	OutputTo "DISCNUMBER"
 	FindLine "\"discNumber\":"
 	FindInLine "\"discNumber\":"

--- a/iTunes#Korea.src
+++ b/iTunes#Korea.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=KR&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=KR&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=KR&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=KR&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Poland.src
+++ b/iTunes#Poland.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=PL&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=PL&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=PL&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=PL&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Portugal.src
+++ b/iTunes#Portugal.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=PT&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=PT&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=PT&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=PT&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Romania.src
+++ b/iTunes#Romania.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=RO&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=RO&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=RO&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=RO&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Russia.src
+++ b/iTunes#Russia.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=RU&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=RU&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=RU&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=RU&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Serbia.src
+++ b/iTunes#Serbia.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=RS&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=RS&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=RS&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=RS&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Singapore.src
+++ b/iTunes#Singapore.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=SG&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=SG&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=SG&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=SG&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Slovakia.src
+++ b/iTunes#Slovakia.src
@@ -9,13 +9,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=SK&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=SK&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=SK&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=SK&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Slovenia.src
+++ b/iTunes#Slovenia.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=SI&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=SI&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=SI&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=SI&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#South Africa.src
+++ b/iTunes#South Africa.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=ZA&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=ZA&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=ZA&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=ZA&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Spain.src
+++ b/iTunes#Spain.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=ES&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=ES&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=ES&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=ES&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Sri Lanka.src
+++ b/iTunes#Sri Lanka.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=LK&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=LK&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=LK&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=LK&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#St. Kitts and Nevis.src
+++ b/iTunes#St. Kitts and Nevis.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=KN&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=KN&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=KN&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=KN&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#St. Lucia.src
+++ b/iTunes#St. Lucia.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=LC&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=LC&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=LC&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=LC&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#St. Vincent and The Grenadines.src
+++ b/iTunes#St. Vincent and The Grenadines.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=VC&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=VC&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=VC&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=VC&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Suriname.src
+++ b/iTunes#Suriname.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=SR&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=SR&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=SR&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=SR&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Sweden.src
+++ b/iTunes#Sweden.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=SE&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=SE&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=SE&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=SE&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Switzerland.src
+++ b/iTunes#Switzerland.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=CH&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=CH&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=CH&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=CH&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Thailand.src
+++ b/iTunes#Thailand.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=TH&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=TH&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=TH&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=TH&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Turkey.src
+++ b/iTunes#Turkey.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=TR&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=TR&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=TR&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=TR&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#USA.src
+++ b/iTunes#USA.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=US&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=US&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=US&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=US&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Uganda.src
+++ b/iTunes#Uganda.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=UG&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=UG&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=UG&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=UG&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Ukraine.src
+++ b/iTunes#Ukraine.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=UA&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=UA&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=UA&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=UA&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#United Kingdom.src
+++ b/iTunes#United Kingdom.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=GB&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=GB&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=GB&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=GB&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Uruguay.src
+++ b/iTunes#Uruguay.src
@@ -9,13 +9,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=UY&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=UY&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=UY&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=UY&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Uzbekistan.src
+++ b/iTunes#Uzbekistan.src
@@ -9,13 +9,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=UZ&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=UZ&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=UZ&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=UZ&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Venezuela.src
+++ b/iTunes#Venezuela.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=VE&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=VE&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=VE&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=VE&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Vietnam.src
+++ b/iTunes#Vietnam.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=VN&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=VN&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=VN&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=VN&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #

--- a/iTunes#Yemen.src
+++ b/iTunes#Yemen.src
@@ -10,13 +10,13 @@
 #          SEARCH BY DIALOG                            #
 ########################################################
 [Name]=iTunes
-[BasedOn]=http://itunes.apple.com
-[IndexUrl]=http://itunes.apple.com/search?country=YE&entity=album&term=%s
-[AlbumUrl]=http://itunes.apple.com/lookup?country=YE&entity=song&limit=200&id=
+[BasedOn]=https://itunes.apple.com
+[IndexUrl]=https://itunes.apple.com/search?country=YE&entity=album&term=%s
+[AlbumUrl]=https://itunes.apple.com/lookup?country=YE&entity=song&limit=200&id=
 [WordSeperator]=+
 [IndexFormat]=%_preview%|%_url%|%Artist%|%Album%|%Year%|%Tracks%|%Type%|%Copyright%|
 [SearchBy]=%artist% %album%
-[Encoding]=utf-8
+[Encoding]=url-utf-8
 
 ########################################################
 #          LIST OF SEARCH RESULTS DIALOG               #


### PR DESCRIPTION
1. after mp3tag 2.74, client supports https.
2. fix issue: failed to search with chinese characters.